### PR TITLE
add catch handler in socket.js autoRelease to release the conn

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -100,7 +100,7 @@ class MongoSocket {
       }).catch(err => {
         this.pool.release(connection);
         throw err;
-      })
+      });
     }).then(data => {
       this.pool.release(data.connection);
       return data.data;

--- a/src/socket.js
+++ b/src/socket.js
@@ -97,7 +97,10 @@ class MongoSocket {
     return this.pool.acquire().then(connection => {
       return Promise.resolve(fn(connection)).then(data => {
         return {data, connection};
-      });
+      }).catch(err => {
+        this.pool.release(connection);
+        throw err;
+      })
     }).then(data => {
       this.pool.release(data.connection);
       return data.data;


### PR DESCRIPTION
当执行insert数据并遇到unique索引错误时，程序抛错所以不会执行104(修改后)行then方法，导致该connection一直未释放被占用，进而导致后续所有使用mongo的js代码hung住，因为已经获取不到有效可用的连接了。
在1.0.8的commit中有小伙伴添加获取连接超时的option，但实际是一旦出现上述情况，之后所有mongo连接都会获取超时。