### PR TITLE
socket pool size use config.options.poolSize first

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -71,7 +71,7 @@ class MongoSocket {
     };
     const options = {
       min: 1,
-      max: (this.config.options && this.config.options.poolSize) || this.config.connectionLimit || 1,
+      max: (this.config.options && (this.config.options.poolSize || this.config.options.maxPoolSize)) || this.config.connectionLimit || 5,
       acquireTimeoutMillis: this.config.acquireTimeoutMillis || 3000
     };
     return genericPool.createPool(factory, options);

--- a/src/socket.js
+++ b/src/socket.js
@@ -71,7 +71,7 @@ class MongoSocket {
     };
     const options = {
       min: 1,
-      max: this.config.connectionLimit || 1,
+      max: (this.config.options && this.config.options.poolSize) || this.config.connectionLimit || 1,
       acquireTimeoutMillis: this.config.acquireTimeoutMillis || 3000
     };
     return genericPool.createPool(factory, options);

--- a/test/socket.js
+++ b/test/socket.js
@@ -22,3 +22,26 @@ test.serial('close', async t => {
   t.is(!!connection, true);
   const ret = await socket.close(connection);
 });
+
+const connectionLimitConfig = {
+  database: 'think_db',
+  connectionLimit: 5
+};
+test.serial('pool size is config.connectionLimitConfig', async t => {
+  const socket = Socket.getInstance(connectionLimitConfig);
+  const pool = await socket.pool;
+  t.is(pool.max, 5);
+});
+
+const poolSizeConfig = {
+  database: 'think_db',
+  connectionLimit: 5,
+  options: {
+    poolSize: 10
+  }
+};
+test.serial('pool size is config.options.poolSize', async t => {
+  const socket = Socket.getInstance(poolSizeConfig);
+  const pool = await socket.pool;
+  t.is(pool.max, 10);
+});

--- a/test/socket.js
+++ b/test/socket.js
@@ -23,25 +23,47 @@ test.serial('close', async t => {
   const ret = await socket.close(connection);
 });
 
-const connectionLimitConfig = {
-  database: 'think_db',
-  connectionLimit: 5
-};
-test.serial('pool size is config.connectionLimitConfig', async t => {
-  const socket = Socket.getInstance(connectionLimitConfig);
+test.serial('default value of pool size is 5', async t => {
+  const socket = Socket.getInstance(defaultConfig);
   const pool = await socket.pool;
   t.is(pool.max, 5);
 });
 
+const connectionLimitConfig = {
+  database: 'think_db',
+  connectionLimit: 10
+};
+
+test.serial('pool size is config.connectionLimitConfig', async t => {
+  const socket = Socket.getInstance(connectionLimitConfig);
+  const pool = await socket.pool;
+  t.is(pool.max, 10);
+});
+
+const maxPoolSizeConfig = {
+  database: 'think_db',
+  connectionLimit: 10,
+  options: {
+    maxPoolSize: 15
+  }
+};
+
+test.serial('pool size is config.options.maxPoolSize', async t => {
+  const socket = Socket.getInstance(maxPoolSizeConfig);
+  const pool = await socket.pool;
+  t.is(pool.max, 15);
+});
+
 const poolSizeConfig = {
   database: 'think_db',
-  connectionLimit: 5,
+  connectionLimit: 10,
   options: {
-    poolSize: 10
+    maxPoolSize: 15,
+    poolSize: 20
   }
 };
 test.serial('pool size is config.options.poolSize', async t => {
   const socket = Socket.getInstance(poolSizeConfig);
   const pool = await socket.pool;
-  t.is(pool.max, 10);
+  t.is(pool.max, 20);
 });


### PR DESCRIPTION
socket.js里面有一个内部的pool，每次做数据库操作的时候，需要`this.pool.acquire()`，但是这个pool的最小为1，最大为是`this.config.connectionLimit`，最大默认为1。
```
    const options = {
      min: 1,
      max: this.config.connectionLimit || 1,
      acquireTimeoutMillis: this.config.acquireTimeoutMillis || 3000
    };
```
如果按照默认值来，connectionLimit为1，我设置mongo连接poolSize为5，假设我现在有5个请求过来，每次请求需要查询A表（耗时查询），因为socket.js里的pool存在，我只能等待上一个查询操作完成，socket.js里的pool被释放`this.pool.release(data.connection)`，下一个查询操作才会被发送，而我们明明通过poolSize能与数据库建立5个链接，这样显然不合理。
而且`connectionLimit`这个选项在[文档](https://thinkjs.org/zh-cn/doc/3.0/mongo.html)并没有任何描述。
因此我认为应该默认使用this.config.options.poolSize去设置socket.js里的pool大小。