### PR TITLE
connectionLimit如果存在,就不去取poolSize和maxPoolSize了

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -71,7 +71,7 @@ class MongoSocket {
     };
 
     let { connectionLimit, options } = this.config;
-    if (options && (options.poolSize || options.maxPoolSize)) {
+    if (!connectionLimit && options && (options.poolSize || options.maxPoolSize)) {
       connectionLimit = options.poolSize || options.maxPoolSize;
     }
     if (helper.isTrueEmpty(connectionLimit)) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -31,7 +31,11 @@ test.serial('default value of pool size is 5', async t => {
 
 const connectionLimitConfig = {
   database: 'think_db',
-  connectionLimit: 10
+  connectionLimit: 10,
+  options: {
+    maxPoolSize: 15,
+    poolSize: 20
+  }
 };
 
 test.serial('pool size is config.connectionLimitConfig', async t => {
@@ -42,7 +46,6 @@ test.serial('pool size is config.connectionLimitConfig', async t => {
 
 const maxPoolSizeConfig = {
   database: 'think_db',
-  connectionLimit: 10,
   options: {
     maxPoolSize: 15
   }
@@ -56,7 +59,6 @@ test.serial('pool size is config.options.maxPoolSize', async t => {
 
 const poolSizeConfig = {
   database: 'think_db',
-  connectionLimit: 10,
   options: {
     maxPoolSize: 15,
     poolSize: 20


### PR DESCRIPTION
上次pr解决了一个问题，但随之而来又有一个问题。

think-mongo维护generic-pool, generic-pool中的每个resource维护mongodbConnection pool。
要发起一个查询，首先pool.acquire()得到一个mongodbConnection，而这个mongodbConnection再被释放之前无法接受其他查询，所以无论poolSize和maxPoolSize设置多大的值，一个mongodbConnection同一时间只能进行数据库操作。
所以如果设置了poolSize为10，会导致generic-pool大小为10(这个10有意义)，generic-pool下每个resource下的mongodbConnection pool为10（但这个10个连接池只会被用到1个，非常不合理）。

按照现在的逻辑来说，我希望generic-pool大小为10，mongodbConnection poolSize为1，但如果设置maxConnectionLimit为10，poolSize为1，maxConnection会被覆盖成1。