### PR TITLE
[feature] adapter mongodb 4.x version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/thinkjs/think-mongo#readme",
   "dependencies": {
     "generic-pool": "^3.1.7",
-    "mongodb": "^2.2.30",
+    "mongodb": "^3.5.9",
     "think-helper": "^1.0.5",
     "think-instance": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "think-mongo",
-  "version": "1.0.12",
+  "version": "2.0.0",
   "description": "Mongo adaper",
   "scripts": {
     "watch": "babel ./src --out-dir ./lib --watch",

--- a/src/socket.js
+++ b/src/socket.js
@@ -62,7 +62,7 @@ class MongoSocket {
         if (config.logConnect) {
           config.logger(connectStr);
         }
-        return mongoConnect(connectStr);
+        return mongoConnect(connectStr, {useUnifiedTopology: true});
       },
       destroy: client => {
         client.close();
@@ -104,7 +104,7 @@ class MongoSocket {
    */
   autoRelease(fn) {
     return this.pool.acquire().then(connection => {
-      return Promise.resolve(fn(connection)).then(data => {
+      return Promise.resolve(fn(connection.db())).then(data => {
         return { data, connection };
       }).catch(err => {
         this.pool.release(connection);


### PR DESCRIPTION
Update `mongodb` module to adapter mongodb 4.x version.

The big difference with mongodb 4.x and old: https://github.com/mongodb/node-mongodb-native/blob/master/CHANGES_3.0.0.md

You can try it by using `npm install think-mongo@next`.