### PR TITLE
feat: add raw export for count() and sum()

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -487,11 +487,12 @@ class Mongo {
   /**
    * get count
    * @param  {String} field []
+   * @param {Object} options
    * @return {Promise}       []
    */
-  count(field) {
+  count(field, options) {
     this.field(field);
-    const options = this.parseOptions();
+    options = this.parseOptions(options);
     return this.db().count(options);
   }
   /**

--- a/src/model.js
+++ b/src/model.js
@@ -491,6 +491,10 @@ class Mongo {
    * @return {Promise}       []
    */
   count(field, options) {
+    if (helper.isObject(field) && !options) {
+      options = field;
+      field = undefined;
+    }
     this.field(field);
     options = this.parseOptions(options);
     return this.db().count(options);
@@ -498,11 +502,16 @@ class Mongo {
   /**
    * get sum
    * @param  {String} field []
+   * @param {Object} options
    * @return {Promise}       []
    */
-  sum(field) {
+  sum(field, options) {
+    if (helper.isObject(field) && !options) {
+      options = field;
+      field = undefined;
+    }
     this.field(field);
-    const options = this.parseOptions();
+    options = this.parseOptions(options);
     return this.db().sum(options);
   }
   /**

--- a/src/query.js
+++ b/src/query.js
@@ -199,7 +199,7 @@ module.exports = class Query {
         const toArray = helper.promisify(cursor.toArray, cursor);
         return toArray();
       }).then(data => {
-        return (data[0] && data[0].total) || 0;
+        return options.raw ? data : ((data[0] && data[0].total) || 0);
       });
     });
   }
@@ -238,7 +238,7 @@ module.exports = class Query {
           });
           return ret;
         }
-        return (data[0] && data[0].total) || 0;
+        return options.raw ? data : ((data[0] && data[0].total) || 0);
       });
     });
   }


### PR DESCRIPTION
`think-mongo` only return first line data in `count()` and `sum()` method, but we have some needs return all of data like we want to get every user comment count.

so I add `raw` option to make it. Now you can use it like:


```js
this.mongo('comment').where({ status: 'approved' }).group('user_id').count({ raw: true });
```

it will return like

```js
[
  { _id: { user_id: 1 }, total: 1 },
  { _id: { user_id: 2 }, total: 2 }
]
```
